### PR TITLE
fix(eval): prevent KeyError in evaluate_f1 for prompt data type

### DIFF
--- a/eval/eval_stream.py
+++ b/eval/eval_stream.py
@@ -177,7 +177,7 @@ class SafetyEvaluator:
                         predictions_strict.append(prediction)
                         predictions_loose.append(prediction)
                 else: # prompt
-                    prediction = self.label_map[pred_data[-1]]
+                    prediction = pred_data[-1]
                     if "Controversial" == prediction:
                         predictions_strict.append("Unsafe")
                         predictions_loose.append("Safe")


### PR DESCRIPTION
## What is the purpose of this PR

> 此PR由AI辅助生成，已通过静态检查，但核心逻辑变更请重点复核。

Fixes a `KeyError` regression in `SafetyEvaluator.evaluate_f1` that made the `--data_type prompt` evaluation mode entirely unusable.

## Problem

In `eval/eval_stream.py`, the `evaluate_f1` method maps integers (`{0,1,2}`) to label strings (`Safe`/`Unsafe`/`Controversial`) once on line 169:

```python
pred_data = [self.label_map[i] for i in obj_json['pred_risk_levels']]
```

The `response` branch (line 172) uses `pred_data` directly. However, the `prompt` branch (line 180, before fix) was applying `self.label_map` a *second* time to an already-mapped string:

```python
prediction = self.label_map[pred_data[-1]]  # raises KeyError
```

Because `self.label_map` is keyed by integers, this raised `KeyError: 'Safe'` (or `'Unsafe'`/`'Controversial'`) and crashed the F1 computation whenever `--data_type prompt` was selected.

## Source Code Location

- File: `eval/eval_stream.py`
- Line: 180 (original) → 180 (after fix)
- Diff:
```diff
                 else: # prompt
-                    prediction = self.label_map[pred_data[-1]]
+                    prediction = pred_data[-1]
                     if "Controversial" == prediction:
```

## Changes

- Removed the redundant `self.label_map` lookup in the `prompt` branch of `evaluate_f1`.
- The `prompt` branch now mirrors the `response` branch behavior: it consumes `pred_data` (already mapped to label strings) directly.
- No API change, no model behavior change, no change to `label_map` definition.

## Testing

Local verification (Python 3.13):

1. Constructed a JSONL with mixed `pred_risk_levels` of `[0]`, `[1,1]`, `[2]`, `[0,0,0]`, `[1]`.
2. Ran `SafetyEvaluator.evaluate_f1(path, data_type='prompt')` against it.
3. **Before fix:** `KeyError: 'Safe'` (or `'Unsafe'`/`'Controversial'`).
4. **After fix:** F1 computation completes successfully; metrics printed for both strict and loose modes.
5. Regression check: `data_type='response'` branch continues to produce correct results unchanged.

## Notes

- This is the same defect that was previously reported in PR #11 (closed without merge on 2026-04-18). The current PR is a re-attempt with a clearer problem description and a verified local test trace. @haidequanbu @chenhan97 — pinging the previous reviewers in case there is any reason to keep the original branch open instead of this one.
- Change is intentionally minimal (1 line) to keep review surface area small and make any potential conflict trivial to resolve.

## Checklist
- [x] Code follows the project's existing style (the change is identical in form to the surrounding `if data_type == 'response':` branch)
- [x] Local reproduction + verification performed (KeyError → success)
- [x] Regression check on the `response` branch performed
- [x] Commit message follows conventional format
- [x] No new dependencies introduced
